### PR TITLE
Lazyloading

### DIFF
--- a/PhotoCube/Client/src/components/Filter.ts
+++ b/PhotoCube/Client/src/components/Filter.ts
@@ -3,6 +3,6 @@
  */
  export interface Filter{
     type: string,
-    Id: number, 
+    id: number, 
     name: string
 }

--- a/PhotoCube/Client/src/components/LeftDock/DateFilter.tsx
+++ b/PhotoCube/Client/src/components/LeftDock/DateFilter.tsx
@@ -40,7 +40,7 @@ import '../../css/LeftDock/DateFilter.css';
 
     const addFilter = (option: Tag) => {
         const filter: Filter = createFilter(option.name, option.id, "date");
-        if (!props.activeFilters.some(af => af.Id === filter.Id)) {
+        if (!props.activeFilters.some(af => af.id === filter.id)) {
             props.onFiltersChanged(filter);
             updatePrevious(filter);
             updateSelection(filter);
@@ -50,7 +50,7 @@ import '../../css/LeftDock/DateFilter.css';
     const replaceFilter = (option: Tag) => {
         updatePrevious(selectedFilter);
         const newFilter: Filter = createFilter(option.name, option.id, "date");
-        if (!props.activeFilters.some(af => af.Id === newFilter.Id)) {
+        if (!props.activeFilters.some(af => af.id === newFilter.id)) {
             props.onFilterReplaced(selectedFilter!, newFilter);
             updateSelection(newFilter);
         }
@@ -64,7 +64,7 @@ import '../../css/LeftDock/DateFilter.css';
 
     const onClear = () => {
         if (selectedFilter !== null) {
-            props.onFilterRemoved(selectedFilter.Id);
+            props.onFilterRemoved(selectedFilter.id);
             updatePrevious(null);
             updateSelection(null);
             updateDisplay("");

--- a/PhotoCube/Client/src/components/LeftDock/DateFilter.tsx
+++ b/PhotoCube/Client/src/components/LeftDock/DateFilter.tsx
@@ -24,14 +24,10 @@ import '../../css/LeftDock/DateFilter.css';
     }, []);
 
     async function FetchTagsByTagsetName () {
-        //console.log("fetching from dateFilter")
         const response = await Fetcher.FetchTagsByTagsetName(props.tagsetName);
-        //console.log("response to datefilter", response);
         const tags: Tag[] = response.map((t: Tag) => {return {id: t.id, name: t.name }});
         //sort tags
-        //tags.forEach(t => console.log("unsorted tag", t))
         tags.sort((a,b) => parseInt(a.name) - parseInt(b.name));
-        //tags.forEach(t => console.log("sorted tag", t))
         //format days and months
         const formattedTags = formatTags(tags);
         //set dropdown options

--- a/PhotoCube/Client/src/components/LeftDock/DayOfWeekFilter.tsx
+++ b/PhotoCube/Client/src/components/LeftDock/DayOfWeekFilter.tsx
@@ -40,17 +40,10 @@ export default class DayOfWeekFilter extends React.Component<{
      * Fetches tags in Day of Week tagset from the server, and presents them with a checkbox.
      */
     private async renderDaysOfWeek() {
-        //console.log("fetching from dayOfTheWeekFilter")
         const response = await Fetcher.FetchTagsByTagsetName("Day of week (number)")
-        //console.log("response to dayoftheweekfilet", response)
         const DOW: Tag[] = response;
-        //DOW.forEach(d => console.log("dow", d))
         DOW.sort((a,b) => parseInt(a.name) - parseInt(b.name));
-        //DOW.forEach(d => console.log("dow", d))
         this.setState({daysOfWeek: DOW})
-       /*  this.state.daysOfWeek.forEach(day => {
-            console.log("this is a day", day)
-        }) */
     }
 
     /**

--- a/PhotoCube/Client/src/components/LeftDock/DayOfWeekFilter.tsx
+++ b/PhotoCube/Client/src/components/LeftDock/DayOfWeekFilter.tsx
@@ -84,7 +84,7 @@ export default class DayOfWeekFilter extends React.Component<{
         } else {
             //Remove filter
             const filterId = parseInt(e.target.value);
-            if (this.props.activeFilters.some(af => af.Id === filterId)) {
+            if (this.props.activeFilters.some(af => af.id === filterId)) {
                 this.props.onFilterRemoved(filterId);
             }
         }

--- a/PhotoCube/Client/src/components/LeftDock/TagFilter.tsx
+++ b/PhotoCube/Client/src/components/LeftDock/TagFilter.tsx
@@ -17,7 +17,7 @@ const TagFilter = (props: {
 
     useEffect(() => {
         updateSelection(props.selectedTag);
-        if (!props.activeFilters.some(af => af.Id === props.selectedTag.id)) {
+        if (!props.activeFilters.some(af => af.id === props.selectedTag.id)) {
             disableButton(false);
         } else {
             disableButton(true);
@@ -26,7 +26,7 @@ const TagFilter = (props: {
 
     const onButtonClick = () => {
         const filter: Filter = createFilter(selectedTag!.name, selectedTag!.id, "tag");
-        if (!props.activeFilters.some(af => af.Id === filter.Id)) {
+        if (!props.activeFilters.some(af => af.id === filter.id)) {
             props.onFiltersChanged(filter);
             disableButton(true);
         }

--- a/PhotoCube/Client/src/components/Middle/BottomDock/HierarchyBrowser.tsx
+++ b/PhotoCube/Client/src/components/Middle/BottomDock/HierarchyBrowser.tsx
@@ -108,12 +108,12 @@ export const HierarchyBrowser =
 
     const onSelect = (node: Node) => {
         updateSelection(node);
-        disableButton(props.activeFilters.some(af => af.Id === node.id));
+        disableButton(props.activeFilters.some(af => af.id === node.id));
     }
 
     const onButtonClick = () => {
-        const filter: Filter = createFilter(selectedNode!.name, selectedNode!.id, "hierarchy");
-        if (!props.activeFilters.some(af => af.Id === filter.Id)) {
+        const filter: Filter = createFilter(selectedNode!.name, selectedNode!.id, "node");
+        if (!props.activeFilters.some(af => af.id === filter.id)) {
             props.onFiltersChanged(filter);
             disableButton(true);
         }

--- a/PhotoCube/Client/src/components/Middle/BottomDock/HierarchyBrowser.tsx
+++ b/PhotoCube/Client/src/components/Middle/BottomDock/HierarchyBrowser.tsx
@@ -141,7 +141,6 @@ export const HierarchyBrowser =
 
 //utility function
 async function fetchChildNodes(nodeId: number){
-    //console.log("from hierachybrow", nodeId)
     const response = await Fetcher.FetchChildNodes(nodeId);
     let children = [];
         if (response.length > 0) {

--- a/PhotoCube/Client/src/components/Middle/BottomDock/TagsetFilter.tsx
+++ b/PhotoCube/Client/src/components/Middle/BottomDock/TagsetFilter.tsx
@@ -28,7 +28,7 @@ export const TagsetDropdown = (props: {onFiltersChanged: (filter: Filter) => voi
 
     const addFilter = () => {
         const filter: Filter = createFilter(selectedTagset!.name, selectedTagset!.id, "tagset");
-        if (!props.activeFilters.some(af => af.Id === filter.Id)) {
+        if (!props.activeFilters.some(af => af.id === filter.id)) {
             props.onFiltersChanged(filter);
             disableButton(true);
         }
@@ -36,7 +36,7 @@ export const TagsetDropdown = (props: {onFiltersChanged: (filter: Filter) => voi
 
     const updateDropdown = (e: Option) => {
         updateSelection({id: parseInt(e.value), name: e.label!.toString(), tags: null});
-        disableButton(props.activeFilters.some(af => af.Id === parseInt(e.value)));
+        disableButton(props.activeFilters.some(af => af.id === parseInt(e.value)));
     }
 
     return (
@@ -50,7 +50,7 @@ export const TagsetDropdown = (props: {onFiltersChanged: (filter: Filter) => voi
 //utility function
 export const createFilter = (tagName: string, id: number, type: string) => {
     const filter: Filter = {
-        Id: id,
+        id: id,
         type: type,
         name: tagName
     }

--- a/PhotoCube/Client/src/components/Middle/CubeBrowser/Cell.ts
+++ b/PhotoCube/Client/src/components/Middle/CubeBrowser/Cell.ts
@@ -58,7 +58,6 @@ export default class Cell{
         this.z = aPosition.z;
         this.CubeObjects = cubeObjectData;
         if(cubeObjectData.length > 0){
-            //console.log(this.CubeObjects[0].fileURI)
             this.threeObject = addCubeCallback(process.env.REACT_APP_IMAGE_SERVER + this.CubeObjects[0].fileURI, {x: this.x, y: this.y, z:this.z});
             this.threeObject.userData = { x: this.x, y: this.y, z:this.z, size: this.count, cubeObjects: this.CubeObjects };
             //this.ToggleSwitchingImagesEveryXms(10000);

--- a/PhotoCube/Client/src/components/Middle/CubeBrowser/CubeBrowser.tsx
+++ b/PhotoCube/Client/src/components/Middle/CubeBrowser/CubeBrowser.tsx
@@ -27,7 +27,7 @@ export default class CubeBrowser extends React.Component<{
         onFileCountChanged: (fileCount: number) => void,
         previousBrowsingState: BrowsingState|null,
         onOpenCubeInCardMode: (cubeObjects: CubeObject[]) => void,
-        onOpenCubeInGridMode: (cubeObjects: CubeObject[]) => void,
+        onOpenCubeInGridMode: (cubeObjects: CubeObject[], info: string, obj: object, s: string) => void,
         filters: Filter[]
     }>{
 
@@ -36,6 +36,9 @@ export default class CubeBrowser extends React.Component<{
         infoText: "Hover with mouse on a cube to see info",
         showContextMenu: false,
         showErrorMessage: false,
+        infostring: "",
+        obj: {},
+        s: "",
     };
 
     render(){
@@ -300,9 +303,119 @@ export default class CubeBrowser extends React.Component<{
             let y = (me.clientY + 20) + 'px';
             conMenu!.style.top = y;
             conMenu!.style.left = x;
-            this.setState({showContextMenu: true});
+            //this.setState({showContextMenu: true});
             this.contextMenuCubeObjects = intersects[0].object.userData.cubeObjects;
+            console.log("Userdata:", intersects[0].object.userData)
+            let xDefined : boolean = this.xAxis.TitleString !== "X";
+            let yDefined : boolean = this.yAxis.TitleString !== "Y";
+            let zDefined : boolean = this.zAxis.TitleString !== "Z";
+            let infoText : string = "Number of photos: " + intersects[0].object.userData.size;
+            let arrx: number[] = []; 
+            let arry: number[] = []; 
+            let arrz: number[] = []; 
+            let ob = {
+                size: 0,
+                isProjected: false,
+                x: {
+                    parentType: "",
+                    parentId: 0,
+                    type: "",
+                    ids: arrx
+                },
+                y: {
+                    parentType: "",
+                    parentId: 0,
+                    type: "",
+                    ids: arry
+                },
+                z: {
+                    parentType: "",
+                    parentId: 0,
+                    type: "",
+                    ids: arrz  
+                } 
+                 
+            }
+            ob.size = intersects[0].object.userData.size;
+            if(xDefined){
+                ob.isProjected = true
+                if(intersects[0].object.userData.x !== 0 && this.xAxis.AxisType === AxisTypeEnum.Tagset){
+                    infoText += ",  X: " + (this.xAxis.TitleString + ": " + this.xAxis.Tags[parseInt(intersects[0].object.userData.x) - 1].id)
+                    ob.x.parentType = this.xAxis.AxisType
+                    ob.x.parentId = this.xAxis.Id
+                    ob.x.type = "tag"
+                    ob.x.ids.push(this.xAxis.Tags[parseInt(intersects[0].object.userData.x) - 1].id)
+                }else if(this.xAxis.AxisType === AxisTypeEnum.Hierarchy){
+                    infoText += ",  X: " + (this.xAxis.TitleString + ": " + this.xAxis.Hierarchies[parseInt(intersects[0].object.userData.x) - 1].id)
+                    ob.x.parentType = this.xAxis.AxisType
+                    ob.x.parentId = this.xAxis.Id 
+                    ob.x.type = "node"
+                    ob.x.ids.push(this.xAxis.Hierarchies[parseInt(intersects[0].object.userData.x) - 1].id)
+                }
+                else if(this.xAxis.AxisType === AxisTypeEnum.HierarchyLeaf){
+                    infoText += ",  X: " + (this.xAxis.Hierarchies[parseInt(intersects[0].object.userData.x) - 1].id)
+                    ob.x.parentType = this.xAxis.AxisType
+                    ob.x.parentId = this.xAxis.Id
+                    ob.x.type = "hierarchyLeaf"
+                    ob.x.ids.push(this.xAxis.Hierarchies[parseInt(intersects[0].object.userData.x) - 1].id)
+                }
+            }
+            if(yDefined){
+                ob.isProjected = true
+                if(intersects[0].object.userData.y !== 0 && this.yAxis.AxisType === AxisTypeEnum.Tagset){
+                    infoText += ",  Y: " + (this.yAxis.TitleString + ": " + this.yAxis.Tags[parseInt(intersects[0].object.userData.y) - 1].id);
+                    ob.y.parentType = this.yAxis.AxisType
+                    ob.y.parentId = this.yAxis.Id
+                    ob.y.type = "tag"
+                    ob.y.ids.push(this.yAxis.Tags[parseInt(intersects[0].object.userData.y) - 1].id)
+                }else if(this.yAxis.AxisType === AxisTypeEnum.Hierarchy){
+                    infoText += ",  Y: " + (this.yAxis.TitleString + ": " + this.yAxis.Hierarchies[parseInt(intersects[0].object.userData.y) - 1].id);
+                    ob.y.parentType = this.yAxis.AxisType
+                    ob.y.parentId = this.yAxis.Id
+                    ob.y.type = "node"
+                    ob.y.ids.push(this.yAxis.Hierarchies[parseInt(intersects[0].object.userData.y) - 1].id)
+                }else if(this.yAxis.AxisType === AxisTypeEnum.HierarchyLeaf){
+                    infoText += ",  Y: " + (this.yAxis.Hierarchies[parseInt(intersects[0].object.userData.y) - 1].id)
+                    ob.y.parentType = this.yAxis.AxisType
+                    ob.y.parentId = this.yAxis.Id
+                    ob.y.type = "hierarchyLeaf"
+                    ob.y.ids.push(this.yAxis.Hierarchies[parseInt(intersects[0].object.userData.y) - 1].id)
+                }
+            }
+            if(zDefined){
+                ob.isProjected = true
+                if(intersects[0].object.userData.z !== 0 && this.zAxis.AxisType === AxisTypeEnum.Tagset){
+                    infoText += ",  Z: " + (this.zAxis.TitleString + ": " + this.zAxis.Tags[parseInt(intersects[0].object.userData.z) - 1].id);
+                    ob.z.parentType = this.zAxis.AxisType
+                    ob.z.parentId = this.zAxis.Id
+                    ob.z.type = "tag"
+                    ob.z.ids.push(this.zAxis.Tags[parseInt(intersects[0].object.userData.z) - 1].id)
+                }else if(this.zAxis.AxisType === AxisTypeEnum.Hierarchy){
+                    infoText += ",  Z: " + (this.zAxis.TitleString + ": " + this.zAxis.Hierarchies[parseInt(intersects[0].object.userData.z) - 1].id);
+                    ob.z.parentType = this.zAxis.AxisType
+                    ob.z.parentId = this.zAxis.Id
+                    ob.z.type = "node"
+                    ob.z.ids.push(this.zAxis.Hierarchies[parseInt(intersects[0].object.userData.z) - 1].id)
+                }else if(this.zAxis.AxisType === AxisTypeEnum.HierarchyLeaf){
+                    infoText += ",  Z: " + (this.zAxis.Hierarchies[parseInt(intersects[0].object.userData.z) - 1].id)
+                    ob.z.parentType = this.zAxis.AxisType
+                    ob.z.parentId = this.zAxis.Id
+                    ob.z.type = "hierarchyLeaf"
+                    ob.z.ids.push(this.zAxis.Hierarchies[parseInt(intersects[0].object.userData.z) - 1].id)
+                }
+            }
+            this.setState({infostring:infoText})
+            this.setState({obj: ob})
+         /* console.log("infotext", infoText)
+            console.log("THE OBJECT", this.state.obj)
+            console.log(this.state.infostring) 
+            console.log("Filters from cubebrowser", this.props.filters) */
+            const s = `https://localhost:5001/api/cell?filters=[{"type": "tag", "ids": [184]},{"type": "node", "ids": [63]}]&all=[]`
+            this.setState({s: s})
+        }else{
+            this.setState({infostring:""})
         }
+        this.onOpenCubeInGridMode()
         return false;
     }
 
@@ -380,7 +493,7 @@ export default class CubeBrowser extends React.Component<{
      * Handler to rightclick - Open cube in grid mode.
      */
     private onOpenCubeInGridMode(){
-        this.props.onOpenCubeInGridMode(this.contextMenuCubeObjects);
+        this.props.onOpenCubeInGridMode(this.contextMenuCubeObjects, this.state.infostring, this.state.obj, this.state.s);
     }
 
     /**

--- a/PhotoCube/Client/src/components/Middle/CubeBrowser/CubeBrowser.tsx
+++ b/PhotoCube/Client/src/components/Middle/CubeBrowser/CubeBrowser.tsx
@@ -30,10 +30,8 @@ export default class CubeBrowser extends React.Component<{
     onOpenCubeInCardMode: (cubeObjects: CubeObject[]) => void;
     onOpenCubeInGridMode: (
         cubeObjects: CubeObject[],
-        info: string,
-        obj: object,
-        s: string,
         projectedFilters: Filter[],
+        isProjected: boolean,
     ) => void;
     filters: Filter[];
 }> {
@@ -46,6 +44,7 @@ export default class CubeBrowser extends React.Component<{
         obj: {},
         s: "",
         projectedFilters: [],
+        isProjected: false,
     };
 
     render() {
@@ -404,57 +403,18 @@ export default class CubeBrowser extends React.Component<{
             conMenu!.style.left = x;
             //this.setState({showContextMenu: true});
             this.contextMenuCubeObjects = intersects[0].object.userData.cubeObjects;
-            console.log("Userdata:", intersects[0].object.userData);
+            //console.log("Userdata:", intersects[0].object.userData);
             let xDefined: boolean = this.xAxis.TitleString !== "X";
             let yDefined: boolean = this.yAxis.TitleString !== "Y";
             let zDefined: boolean = this.zAxis.TitleString !== "Z";
-            let infoText: string =
-                "Number of photos: " + intersects[0].object.userData.size;
-            let arrx: number[] = [];
-            let arry: number[] = [];
-            let arrz: number[] = [];
-            let ob = {
-                size: 0,
-                isProjected: false,
-                x: {
-                    parentType: "",
-                    parentId: 0,
-                    type: "",
-                    ids: arrx,
-                },
-                y: {
-                    parentType: "",
-                    parentId: 0,
-                    type: "",
-                    ids: arry,
-                },
-                z: {
-                    parentType: "",
-                    parentId: 0,
-                    type: "",
-                    ids: arrz,
-                },
-            };
-            ob.size = intersects[0].object.userData.size;
             let projectedFilter: Filter[] = [];
+            let filtersAreProjected = false;
             if (xDefined) {
-                ob.isProjected = true;
+                filtersAreProjected = true;
                 if (
                     intersects[0].object.userData.x !== 0 &&
                     this.xAxis.AxisType === AxisTypeEnum.Tagset
                 ) {
-                    infoText +=
-                        ",  X: " +
-                        (this.xAxis.TitleString +
-                            ": " +
-                            this.xAxis.Tags[parseInt(intersects[0].object.userData.x) - 1]
-                                .id);
-                    ob.x.parentType = this.xAxis.AxisType;
-                    ob.x.parentId = this.xAxis.Id;
-                    ob.x.type = "tag";
-                    ob.x.ids.push(
-                        this.xAxis.Tags[parseInt(intersects[0].object.userData.x) - 1].id
-                    );
                     const xfilter: Filter = createFilter(
                         this.xAxis.Tags[parseInt(intersects[0].object.userData.x) - 1].name,
                         this.xAxis.Tags[parseInt(intersects[0].object.userData.x) - 1].id,
@@ -462,21 +422,6 @@ export default class CubeBrowser extends React.Component<{
                     );
                     projectedFilter.push(xfilter);
                 } else if (this.xAxis.AxisType === AxisTypeEnum.Hierarchy) {
-                    infoText +=
-                        ",  X: " +
-                        (this.xAxis.TitleString +
-                            ": " +
-                            this.xAxis.Hierarchies[
-                                parseInt(intersects[0].object.userData.x) - 1
-                            ].id);
-                    ob.x.parentType = this.xAxis.AxisType;
-                    ob.x.parentId = this.xAxis.Id;
-                    ob.x.type = "node";
-                    ob.x.ids.push(
-                        this.xAxis.Hierarchies[
-                            parseInt(intersects[0].object.userData.x) - 1
-                        ].id
-                    );
                     const xfilter: Filter = createFilter(
                         this.xAxis.Hierarchies[
                             parseInt(intersects[0].object.userData.x) - 1
@@ -488,39 +433,15 @@ export default class CubeBrowser extends React.Component<{
                     );
                     projectedFilter.push(xfilter);
                 } else if (this.xAxis.AxisType === AxisTypeEnum.HierarchyLeaf) {
-                    infoText +=
-                        ",  X: " +
-                        this.xAxis.Hierarchies[
-                            parseInt(intersects[0].object.userData.x) - 1
-                        ].id;
-                    ob.x.parentType = this.xAxis.AxisType;
-                    ob.x.parentId = this.xAxis.Id;
-                    ob.x.type = "hierarchyLeaf";
-                    ob.x.ids.push(
-                        this.xAxis.Hierarchies[
-                            parseInt(intersects[0].object.userData.x) - 1
-                        ].id
-                    );
+                    //what to do in this case, and what is this case??
                 }
             }
             if (yDefined) {
-                ob.isProjected = true;
+                filtersAreProjected = true;
                 if (
                     intersects[0].object.userData.y !== 0 &&
                     this.yAxis.AxisType === AxisTypeEnum.Tagset
                 ) {
-                    infoText +=
-                        ",  Y: " +
-                        (this.yAxis.TitleString +
-                            ": " +
-                            this.yAxis.Tags[parseInt(intersects[0].object.userData.y) - 1]
-                                .id);
-                    ob.y.parentType = this.yAxis.AxisType;
-                    ob.y.parentId = this.yAxis.Id;
-                    ob.y.type = "tag";
-                    ob.y.ids.push(
-                        this.yAxis.Tags[parseInt(intersects[0].object.userData.y) - 1].id
-                    );
                     const yfilter: Filter = createFilter(
                         this.yAxis.Tags[parseInt(intersects[0].object.userData.y) - 1].name,
                         this.yAxis.Tags[parseInt(intersects[0].object.userData.y) - 1].id,
@@ -528,21 +449,6 @@ export default class CubeBrowser extends React.Component<{
                     );
                     projectedFilter.push(yfilter);
                 } else if (this.yAxis.AxisType === AxisTypeEnum.Hierarchy) {
-                    infoText +=
-                        ",  Y: " +
-                        (this.yAxis.TitleString +
-                            ": " +
-                            this.yAxis.Hierarchies[
-                                parseInt(intersects[0].object.userData.y) - 1
-                            ].id);
-                    ob.y.parentType = this.yAxis.AxisType;
-                    ob.y.parentId = this.yAxis.Id;
-                    ob.y.type = "node";
-                    ob.y.ids.push(
-                        this.yAxis.Hierarchies[
-                            parseInt(intersects[0].object.userData.y) - 1
-                        ].id
-                    );
                     const yfilter: Filter = createFilter(
                         this.yAxis.Hierarchies[
                             parseInt(intersects[0].object.userData.y) - 1
@@ -554,40 +460,15 @@ export default class CubeBrowser extends React.Component<{
                     );
                     projectedFilter.push(yfilter);
                 } else if (this.yAxis.AxisType === AxisTypeEnum.HierarchyLeaf) {
-                    infoText +=
-                        ",  Y: " +
-                        this.yAxis.Hierarchies[
-                            parseInt(intersects[0].object.userData.y) - 1
-                        ].id;
-                    ob.y.parentType = this.yAxis.AxisType;
-                    ob.y.parentId = this.yAxis.Id;
-                    ob.y.type = "hierarchyLeaf";
-                    ob.y.ids.push(
-                        this.yAxis.Hierarchies[
-                            parseInt(intersects[0].object.userData.y) - 1
-                        ].id
-                    );
-                    //const yfilter: Filter = createFilter()
+                    //what to do in this case, and what is this case??
                 }
             }
             if (zDefined) {
-                ob.isProjected = true;
+                filtersAreProjected = true;
                 if (
                     intersects[0].object.userData.z !== 0 &&
                     this.zAxis.AxisType === AxisTypeEnum.Tagset
                 ) {
-                    infoText +=
-                        ",  Z: " +
-                        (this.zAxis.TitleString +
-                            ": " +
-                            this.zAxis.Tags[parseInt(intersects[0].object.userData.z) - 1]
-                                .id);
-                    ob.z.parentType = this.zAxis.AxisType;
-                    ob.z.parentId = this.zAxis.Id;
-                    ob.z.type = "tag";
-                    ob.z.ids.push(
-                        this.zAxis.Tags[parseInt(intersects[0].object.userData.z) - 1].id
-                    );
                     const zfilter: Filter = createFilter(
                         this.zAxis.Tags[parseInt(intersects[0].object.userData.z) - 1].name,
                         this.zAxis.Tags[parseInt(intersects[0].object.userData.z) - 1].id,
@@ -595,21 +476,6 @@ export default class CubeBrowser extends React.Component<{
                     );
                     projectedFilter.push(zfilter);
                 } else if (this.zAxis.AxisType === AxisTypeEnum.Hierarchy) {
-                    infoText +=
-                        ",  Z: " +
-                        (this.zAxis.TitleString +
-                            ": " +
-                            this.zAxis.Hierarchies[
-                                parseInt(intersects[0].object.userData.z) - 1
-                            ].id);
-                    ob.z.parentType = this.zAxis.AxisType;
-                    ob.z.parentId = this.zAxis.Id;
-                    ob.z.type = "node";
-                    ob.z.ids.push(
-                        this.zAxis.Hierarchies[
-                            parseInt(intersects[0].object.userData.z) - 1
-                        ].id
-                    );
                     const zfilter: Filter = createFilter(
                         this.zAxis.Hierarchies[
                             parseInt(intersects[0].object.userData.z) - 1
@@ -621,34 +487,12 @@ export default class CubeBrowser extends React.Component<{
                     );
                     projectedFilter.push(zfilter);
                 } else if (this.zAxis.AxisType === AxisTypeEnum.HierarchyLeaf) {
-                    infoText +=
-                        ",  Z: " +
-                        this.zAxis.Hierarchies[
-                            parseInt(intersects[0].object.userData.z) - 1
-                        ].id;
-                    ob.z.parentType = this.zAxis.AxisType;
-                    ob.z.parentId = this.zAxis.Id;
-                    ob.z.type = "hierarchyLeaf";
-                    ob.z.ids.push(
-                        this.zAxis.Hierarchies[
-                            parseInt(intersects[0].object.userData.z) - 1
-                        ].id
-                    );
-                    //const zfilter: Filter = createFilter()
+                    //what to do in this case, and what is this case??
                 }
             }
-            this.setState({ infostring: infoText });
-            this.setState({ obj: ob });
             this.setState({ projectedFilters: projectedFilter })
-            /* console.log("infotext", infoText)
-                  console.log("THE OBJECT", this.state.obj)
-                  console.log(this.state.infostring) 
-                  console.log("Filters from cubebrowser", this.props.filters) */
-            const s = `https://localhost:5001/api/cell?filters=[{"type": "tag", "ids": [184]},{"type": "node", "ids": [63]}]&all=[]`;
-            this.setState({ s: s });
-        } else {
-            this.setState({ infostring: "" });
-        }
+            this.setState({isProjected : filtersAreProjected})
+        } 
         this.onOpenCubeInGridMode();
         return false;
     };
@@ -782,10 +626,8 @@ export default class CubeBrowser extends React.Component<{
     private onOpenCubeInGridMode() {
         this.props.onOpenCubeInGridMode(
             this.contextMenuCubeObjects,
-            this.state.infostring,
-            this.state.obj,
-            this.state.s,
-            this.state.projectedFilters
+            this.state.projectedFilters,
+            this.state.isProjected,
         );
     }
 
@@ -891,7 +733,6 @@ export default class CubeBrowser extends React.Component<{
     private addCubeCallback = (imageUrl: string, aPosition: Position) => {
         //If image is already loaded previously, get it, otherwise load it:
         let imageMaterial: THREE.MeshBasicMaterial;
-        //console.log(imageUrl);
         if (this.boxTextures.has(imageUrl)) {
             imageMaterial = this.boxTextures.get(imageUrl)!;
         } else {
@@ -1175,8 +1016,6 @@ export default class CubeBrowser extends React.Component<{
         //Fetch cells based on which axis are defined:
 
         this.cells = newCells;
-
-        //console.log(this.cells.length)
 
         console.log("Done computing cells");
 

--- a/PhotoCube/Client/src/components/Middle/CubeBrowser/CubeBrowser.tsx
+++ b/PhotoCube/Client/src/components/Middle/CubeBrowser/CubeBrowser.tsx
@@ -506,7 +506,7 @@ export default class CubeBrowser extends React.Component<{
         axis.PickedDimension = dimension;
 
         switch(dimension.type){
-            case "hierarchy":
+            case "node":
                 let rootNode: HierarchyNode = await Fetcher.FetchNode(dimension.id);
                 axis.TitleString = rootNode.tag.name + " (hierarchy)";
                 axis.AddHierarchy(rootNode, this.addTextCallback, this.addLineCallback);
@@ -560,7 +560,7 @@ export default class CubeBrowser extends React.Component<{
 
         //Exclude projected filters in API call
         const filters: Filter[] = this.props.filters.filter(f => 
-            f.Id !== this.xAxis.Id && f.Id !== this.yAxis.Id && f.Id !== this.zAxis.Id);
+            f.id !== this.xAxis.Id && f.id !== this.yAxis.Id && f.id !== this.zAxis.Id);
 
         let newCells: Cell[] = [];
             try {

--- a/PhotoCube/Client/src/components/Middle/CubeBrowser/Fetcher.ts
+++ b/PhotoCube/Client/src/components/Middle/CubeBrowser/Fetcher.ts
@@ -117,6 +117,29 @@ export default class Fetcher {
     }
   }
 
+  static async FetchAllImagesWithProjection(s : string) {
+    try {
+       //const response = await fetch(`${Fetcher.baseUrl}${s}&all=[]`)
+       console.log(s);
+       const response = await fetch(s)
+       const data = await response.json()
+       console.log("From fetchwithProjection", data)
+       return data 
+    } catch (error) {
+      console.error(error)
+    }
+  }
+
+  static async SubmitImage(fileUri: string) {
+    try {
+       const response = await fetch(`https://vbs.itec.aau.at:9443/api/v1/submit?item=${fileUri.slice(11, -4)}&session=${process.env.REACT_APP_SESSIONID}`)
+       const data = await response.json()
+       return data
+    } catch (error) {
+      console.error(error)
+    }
+  }
+
   /**
    * Returns all hierarchies.
    */

--- a/PhotoCube/Client/src/components/Middle/CubeBrowser/Fetcher.ts
+++ b/PhotoCube/Client/src/components/Middle/CubeBrowser/Fetcher.ts
@@ -42,7 +42,6 @@ export default class Fetcher {
     }
     console.log("querystring:", queryString);
     this.latestQuery = queryString;
-    console.log("latestquery: ", this.latestQuery)
     try {
       const response = await fetch(queryString);
       const data = await response.json();
@@ -56,7 +55,6 @@ export default class Fetcher {
   static async FetchAllImagesWithProjection(filters: Filter[]) {
     let queryString: string = this.baseUrl + "/cell/?";
     queryString += "&filters=" + this.parseFilters(filters!) + "&all=[]";
-    console.log("from fetcher projected query", queryString)
     try {
       const response = await fetch(queryString);
       const data = await response.json();
@@ -112,7 +110,6 @@ export default class Fetcher {
    * @param axis
    */
   private static parseAxis(axis: Axis): string {
-    console.log(axis.TitleString);
     return JSON.stringify({
       type: axis.AxisType,
       id: axis.Id,
@@ -120,7 +117,6 @@ export default class Fetcher {
   }
 
   static async FetchAllImages() {
-    console.log("from fetchallimages", Fetcher.latestQuery + "&all=[]");
     try {
       const response = await fetch(Fetcher.latestQuery + "&all=[]");
       const data = await response.json();
@@ -183,13 +179,11 @@ export default class Fetcher {
    */
 
   static async FetchTagsByTagsetName(tagsetName: string) {
-    console.log(Fetcher.baseUrl + "/tagset/name=" + tagsetName);
     try {
       const response = await fetch(
         Fetcher.baseUrl + "/tagset/name=" + tagsetName
       );
       const data = await response.json();
-      //console.log(data)
       return data;
     } catch (error) {
       console.error(error);
@@ -242,10 +236,8 @@ export default class Fetcher {
   static async FetchChildNodes(nodeId: number) {
     try {
       const call = Fetcher.baseUrl + "/node/" + nodeId + "/children";
-      //console.log("call from fetchchildnodes", call)
       const response = await fetch(call);
       const data = await response.json();
-      //console.log("from fetchchildnodes", data)
       return data;
     } catch (error) {
       console.error(error);
@@ -302,8 +294,6 @@ export default class Fetcher {
 
   static async FetchTagsWithCubeObjectId(cubeObjectId: number) {
     try {
-      const call = Fetcher.baseUrl + "/tag?cubeObjectId=" + cubeObjectId;
-      console.log(call);
       const response = await fetch(
         Fetcher.baseUrl + "/tag?cubeObjectId=" + cubeObjectId
       );

--- a/PhotoCube/Client/src/components/Middle/CubeBrowser/Fetcher.ts
+++ b/PhotoCube/Client/src/components/Middle/CubeBrowser/Fetcher.ts
@@ -42,6 +42,7 @@ export default class Fetcher {
     }
     console.log("querystring:", queryString);
     this.latestQuery = queryString;
+    console.log("latestquery: ", this.latestQuery)
     try {
       const response = await fetch(queryString);
       const data = await response.json();
@@ -60,16 +61,16 @@ export default class Fetcher {
     for (var filter of filters) {
       switch (filter.type) {
         case "tagset":
-          result.push({ type: "tagset", ids: [filter.Id] });
+          result.push({ type: "tagset", ids: [filter.id] });
           break;
         case "node":
-          result.push({ type: "node", ids: [filter.Id] });
+          result.push({ type: "node", ids: [filter.id] });
           break;
         case "day of week":
-          dowfilter.ids.push(filter.Id);
+          dowfilter.ids.push(filter.id);
           break;
         case "tag":
-          semfilter.ids.push(filter.Id);
+          semfilter.ids.push(filter.id);
           break;
         case "time":
           let name: string = filter.name;
@@ -77,7 +78,7 @@ export default class Fetcher {
           result.push({ type: "timerange", ids: [3], ranges: [ranges] });
           break;
         default:
-          result.push({ type: "tag", ids: [filter.Id] });
+          result.push({ type: "tag", ids: [filter.id] });
           break;
       }
     }

--- a/PhotoCube/Client/src/components/Middle/CubeBrowser/Fetcher.ts
+++ b/PhotoCube/Client/src/components/Middle/CubeBrowser/Fetcher.ts
@@ -53,6 +53,20 @@ export default class Fetcher {
     }
   }
 
+  static async FetchAllImagesWithProjection(filters: Filter[]) {
+    let queryString: string = this.baseUrl + "/cell/?";
+    queryString += "&filters=" + this.parseFilters(filters!) + "&all=[]";
+    console.log("from fetcher projected query", queryString)
+    try {
+      const response = await fetch(queryString);
+      const data = await response.json();
+      console.log("cubedata", data);
+      return data;
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
   private static parseFilters(filters: Filter[]): string {
     let sorted: Filter[] = filters.sort((a, b) => (a.type > b.type ? 1 : -1));
     var result: any[] = [];
@@ -117,18 +131,7 @@ export default class Fetcher {
     }
   }
 
-  static async FetchAllImagesWithProjection(s : string) {
-    try {
-       //const response = await fetch(`${Fetcher.baseUrl}${s}&all=[]`)
-       console.log(s);
-       const response = await fetch(s)
-       const data = await response.json()
-       console.log("From fetchwithProjection", data)
-       return data 
-    } catch (error) {
-      console.error(error)
-    }
-  }
+  
 
   static async SubmitImage(fileUri: string) {
     try {

--- a/PhotoCube/Client/src/components/Middle/GridBrowser/GridBrowser.tsx
+++ b/PhotoCube/Client/src/components/Middle/GridBrowser/GridBrowser.tsx
@@ -15,48 +15,19 @@ interface FuncProps {
   cubeObjects: CubeObject[];
   onBrowsingModeChanged: (browsingMode: BrowsingModes) => void;
   filters: Filter[];
-  inforstring: string;
-  s: string;
   projectedFilters: Filter[];
-  obj: {
-    size: number;
-    isProjected: boolean;
-    x: {
-      parentType: "";
-      parentId: 0;
-      type: "";
-      ids: [];
-    };
-    y: {
-      parentType: "";
-      parentId: 0;
-      type: "";
-      ids: [];
-    };
-    z: {
-      parentType: "";
-      parentId: 0;
-      type: "";
-      ids: [];
-    };
-  };
+  isProjected: boolean; 
 }
 
 const GridBrowser: React.FC<FuncProps> = (props: FuncProps) => {
   const [images, setImages] = useState<Image[]>([]);
 
-  const [filters, setFilters] = useState<any[]>([]);
-
   useEffect(() => {
-    if (!props.obj.isProjected) {
+    if (!props.isProjected) {
       fetchAllImages();
     } else {
       fetchWithProjection();
     }
-    props.filters.forEach(f => console.log(f.id))
-    console.log("Filters:", props.filters);
-    console.log("the object: ", props.obj);
-    console.log("projectyed fiulters", props.projectedFilters)
     document.addEventListener("keydown", (e) => onKeydown(e));
     return () => {
       document.removeEventListener("keydown", (e) => onKeydown(e));
@@ -65,7 +36,6 @@ const GridBrowser: React.FC<FuncProps> = (props: FuncProps) => {
 
   const fetchWithProjection = async () => {
     const allFilters = [...props.filters, ...props.projectedFilters]
-    console.log(allFilters)
     try {
       const response = await Fetcher.FetchAllImagesWithProjection(allFilters)
       setImages(response)
@@ -104,9 +74,9 @@ const GridBrowser: React.FC<FuncProps> = (props: FuncProps) => {
   return (
     <div className="grid-item">
       <div className="imageContainer">
-        {images.length > 20
+        {images.length > 100
           ? images
-              .slice(0, 20)
+              .slice(0, 100)
               .map((image) => (
                 <img
                   onDoubleClick={() => submitImage(image.fileURI)}

--- a/PhotoCube/Client/src/components/Middle/GridBrowser/GridBrowser.tsx
+++ b/PhotoCube/Client/src/components/Middle/GridBrowser/GridBrowser.tsx
@@ -17,7 +17,7 @@ interface FuncProps {
   filters: Filter[];
   inforstring: string;
   s: string;
-  //obj: {};
+  projectedFilters: Filter[];
   obj: {
     size: number;
     isProjected: boolean;
@@ -45,6 +45,8 @@ interface FuncProps {
 const GridBrowser: React.FC<FuncProps> = (props: FuncProps) => {
   const [images, setImages] = useState<Image[]>([]);
 
+  const [filters, setFilters] = useState<any[]>([]);
+
   useEffect(() => {
     if (!props.obj.isProjected) {
       fetchAllImages();
@@ -54,25 +56,20 @@ const GridBrowser: React.FC<FuncProps> = (props: FuncProps) => {
     props.filters.forEach(f => console.log(f.id))
     console.log("Filters:", props.filters);
     console.log("the object: ", props.obj);
+    console.log("projectyed fiulters", props.projectedFilters)
     document.addEventListener("keydown", (e) => onKeydown(e));
     return () => {
       document.removeEventListener("keydown", (e) => onKeydown(e));
     };
   }, []);
 
-/*   const stringParser = () => {
-    const s = `https://localhost:5001/api/cell?filters=[{"type": "tag", "ids": [184]},{"type": "node", "ids": [63]}]&all=[]`
-    const arr = [props.obj.x.parentId, props.obj.y.parentId, props.obj.z.parentId]
-    const arr2 = Number[]
-    props.filters.forEach(f => arr2.push(f.id))
-    let result = arr2.every(function (element: { id: number; }) {return arr.includes(element)})
-    return s
-  } */
-
   const fetchWithProjection = async () => {
+    const allFilters = [...props.filters, ...props.projectedFilters]
+    console.log(allFilters)
     try {
-      const response = await Fetcher.FetchAllImagesWithProjection(props.s)
+      const response = await Fetcher.FetchAllImagesWithProjection(allFilters)
       setImages(response)
+      console.log(response)
     } catch (error) {
       console.error(error)
     }

--- a/PhotoCube/Client/src/components/Middle/GridBrowser/GridBrowser.tsx
+++ b/PhotoCube/Client/src/components/Middle/GridBrowser/GridBrowser.tsx
@@ -15,19 +15,68 @@ interface FuncProps {
   cubeObjects: CubeObject[];
   onBrowsingModeChanged: (browsingMode: BrowsingModes) => void;
   filters: Filter[];
+  inforstring: string;
+  s: string;
+  //obj: {};
+  obj: {
+    size: number;
+    isProjected: boolean;
+    x: {
+      parentType: "";
+      parentId: 0;
+      type: "";
+      ids: [];
+    };
+    y: {
+      parentType: "";
+      parentId: 0;
+      type: "";
+      ids: [];
+    };
+    z: {
+      parentType: "";
+      parentId: 0;
+      type: "";
+      ids: [];
+    };
+  };
 }
 
 const GridBrowser: React.FC<FuncProps> = (props: FuncProps) => {
-const [images, setImages] = useState<Image[]>([]);
+  const [images, setImages] = useState<Image[]>([]);
 
   useEffect(() => {
-    fetchAllImages();
-    console.log("Filters:", props.filters)
+    if (!props.obj.isProjected) {
+      fetchAllImages();
+    } else {
+      fetchWithProjection();
+    }
+    props.filters.forEach(f => console.log(f.id))
+    console.log("Filters:", props.filters);
+    console.log("the object: ", props.obj);
     document.addEventListener("keydown", (e) => onKeydown(e));
     return () => {
       document.removeEventListener("keydown", (e) => onKeydown(e));
     };
   }, []);
+
+/*   const stringParser = () => {
+    const s = `https://localhost:5001/api/cell?filters=[{"type": "tag", "ids": [184]},{"type": "node", "ids": [63]}]&all=[]`
+    const arr = [props.obj.x.parentId, props.obj.y.parentId, props.obj.z.parentId]
+    const arr2 = Number[]
+    props.filters.forEach(f => arr2.push(f.id))
+    let result = arr2.every(function (element: { id: number; }) {return arr.includes(element)})
+    return s
+  } */
+
+  const fetchWithProjection = async () => {
+    try {
+      const response = await Fetcher.FetchAllImagesWithProjection(props.s)
+      setImages(response)
+    } catch (error) {
+      console.error(error)
+    }
+  }
 
   const fetchAllImages = async () => {
     try {
@@ -37,6 +86,17 @@ const [images, setImages] = useState<Image[]>([]);
       console.error(error);
     }
   };
+
+  const submitImage = async (fileUri: string) => {
+    try {
+      Fetcher.SubmitImage(fileUri).then((r) => {
+        console.log(r);
+      });
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
   const onKeydown = (e: KeyboardEvent) => {
     console.log(e.key);
     if (e.key === "Escape") {
@@ -47,13 +107,25 @@ const [images, setImages] = useState<Image[]>([]);
   return (
     <div className="grid-item">
       <div className="imageContainer">
-        {images.slice(0, 20).map((image) => (
-          <img
-            key={image.id}
-            className="image"
-            src={process.env.REACT_APP_IMAGE_SERVER + image.fileURI}
-          ></img>
-        ))}
+        {images.length > 20
+          ? images
+              .slice(0, 20)
+              .map((image) => (
+                <img
+                  onDoubleClick={() => submitImage(image.fileURI)}
+                  key={image.id}
+                  className="image"
+                  src={process.env.REACT_APP_IMAGE_SERVER + image.fileURI}
+                ></img>
+              ))
+          : images.map((image) => (
+              <img
+                onDoubleClick={() => submitImage(image.fileURI)}
+                key={image.id}
+                className="image"
+                src={process.env.REACT_APP_IMAGE_SERVER + image.fileURI}
+              ></img>
+            ))}
       </div>
     </div>
   );

--- a/PhotoCube/Client/src/components/Middle/GridBrowser/GridBrowser.tsx
+++ b/PhotoCube/Client/src/components/Middle/GridBrowser/GridBrowser.tsx
@@ -4,6 +4,7 @@ import CubeObject from "../CubeBrowser/CubeObject";
 import { BrowsingModes } from "../../RightDock/BrowsingModeChanger";
 import Fetcher from "../CubeBrowser/Fetcher";
 import { Image } from "../../../interfaces/types";
+import { Filter } from "../../Filter";
 
 /**
  * The GridBrowser allows the user to browse a collection of photos side by side in a grid to get an overview.
@@ -11,14 +12,17 @@ import { Image } from "../../../interfaces/types";
  * this.props.onBrowsingModeChanged is a callback funtion that tells parent component that the browsing mode has been changed.
  */
 interface FuncProps {
+  cubeObjects: CubeObject[];
   onBrowsingModeChanged: (browsingMode: BrowsingModes) => void;
+  filters: Filter[];
 }
 
 const GridBrowser: React.FC<FuncProps> = (props: FuncProps) => {
-  const [images, setImages] = useState<Image[]>([]);
+const [images, setImages] = useState<Image[]>([]);
 
   useEffect(() => {
     fetchAllImages();
+    console.log("Filters:", props.filters)
     document.addEventListener("keydown", (e) => onKeydown(e));
     return () => {
       document.removeEventListener("keydown", (e) => onKeydown(e));

--- a/PhotoCube/Client/src/components/PhotoCubeClient.tsx
+++ b/PhotoCube/Client/src/components/PhotoCubeClient.tsx
@@ -35,6 +35,9 @@ export default class PhotoCubeClient extends React.Component<ClientState> {
 
   CubeBrowserBrowsingState : BrowsingState|null = null;
   cubeObjects : CubeObject[] = [];
+  infostring : string | any;
+  obj : object | any;
+  s: string|any;
 
   render() {
     //Conditional rendering:
@@ -47,7 +50,7 @@ export default class PhotoCubeClient extends React.Component<ClientState> {
         onOpenCubeInGridMode={this.onOpenCubeInGridMode}
         filters={this.state.filters}/>
     }else if(this.state.BrowsingMode == BrowsingModes.Grid){
-      currentBrowser = <GridBrowser filters={this.state.filters} cubeObjects={this.cubeObjects} onBrowsingModeChanged={this.onBrowsingModeChanged}/>
+      currentBrowser = <GridBrowser s={this.s} obj={this.obj} inforstring={this.infostring} filters={this.state.filters} cubeObjects={this.cubeObjects} onBrowsingModeChanged={this.onBrowsingModeChanged}/>
     }else if(this.state.BrowsingMode == BrowsingModes.Card){
       currentBrowser = <CardBrowser cubeObjects={this.cubeObjects} onBrowsingModeChanged={this.onBrowsingModeChanged}/>
     }
@@ -198,10 +201,13 @@ export default class PhotoCubeClient extends React.Component<ClientState> {
   /**
    * Can be called from sub-components to open CubeObject array in GridMode.
    */
-  onOpenCubeInGridMode = (cubeObjects: CubeObject[]) => {
+  onOpenCubeInGridMode = (cubeObjects: CubeObject[], infostring: string, obj: object, s: string) => {
     console.log("Opening cube in grid mode:");
     this.CubeBrowserBrowsingState = this.CubeBrowser.current!.GetCurrentBrowsingState();
     this.cubeObjects = cubeObjects;
+    this.infostring = infostring;
+    this.obj = obj;
+    this.s = s;
     this.setState({BrowsingMode: BrowsingModes.Grid});
     this.rightDock.current!.ChangeBrowsingMode(BrowsingModes.Grid);
   }

--- a/PhotoCube/Client/src/components/PhotoCubeClient.tsx
+++ b/PhotoCube/Client/src/components/PhotoCubeClient.tsx
@@ -38,6 +38,7 @@ export default class PhotoCubeClient extends React.Component<ClientState> {
   infostring : string | any;
   obj : object | any;
   s: string|any;
+  projectedFilters : Filter[] = [];
 
   render() {
     //Conditional rendering:
@@ -50,7 +51,7 @@ export default class PhotoCubeClient extends React.Component<ClientState> {
         onOpenCubeInGridMode={this.onOpenCubeInGridMode}
         filters={this.state.filters}/>
     }else if(this.state.BrowsingMode == BrowsingModes.Grid){
-      currentBrowser = <GridBrowser s={this.s} obj={this.obj} inforstring={this.infostring} filters={this.state.filters} cubeObjects={this.cubeObjects} onBrowsingModeChanged={this.onBrowsingModeChanged}/>
+      currentBrowser = <GridBrowser projectedFilters={this.projectedFilters} s={this.s} obj={this.obj} inforstring={this.infostring} filters={this.state.filters} cubeObjects={this.cubeObjects} onBrowsingModeChanged={this.onBrowsingModeChanged}/>
     }else if(this.state.BrowsingMode == BrowsingModes.Card){
       currentBrowser = <CardBrowser cubeObjects={this.cubeObjects} onBrowsingModeChanged={this.onBrowsingModeChanged}/>
     }
@@ -201,13 +202,14 @@ export default class PhotoCubeClient extends React.Component<ClientState> {
   /**
    * Can be called from sub-components to open CubeObject array in GridMode.
    */
-  onOpenCubeInGridMode = (cubeObjects: CubeObject[], infostring: string, obj: object, s: string) => {
+  onOpenCubeInGridMode = (cubeObjects: CubeObject[], infostring: string, obj: object, s: string, projectedFilters: Filter[]) => {
     console.log("Opening cube in grid mode:");
     this.CubeBrowserBrowsingState = this.CubeBrowser.current!.GetCurrentBrowsingState();
     this.cubeObjects = cubeObjects;
     this.infostring = infostring;
     this.obj = obj;
     this.s = s;
+    this.projectedFilters = projectedFilters;
     this.setState({BrowsingMode: BrowsingModes.Grid});
     this.rightDock.current!.ChangeBrowsingMode(BrowsingModes.Grid);
   }

--- a/PhotoCube/Client/src/components/PhotoCubeClient.tsx
+++ b/PhotoCube/Client/src/components/PhotoCubeClient.tsx
@@ -47,7 +47,7 @@ export default class PhotoCubeClient extends React.Component<ClientState> {
         onOpenCubeInGridMode={this.onOpenCubeInGridMode}
         filters={this.state.filters}/>
     }else if(this.state.BrowsingMode == BrowsingModes.Grid){
-      currentBrowser = <GridBrowser /* cubeObjects={this.cubeObjects} */ onBrowsingModeChanged={this.onBrowsingModeChanged}/>
+      currentBrowser = <GridBrowser filters={this.state.filters} cubeObjects={this.cubeObjects} onBrowsingModeChanged={this.onBrowsingModeChanged}/>
     }else if(this.state.BrowsingMode == BrowsingModes.Card){
       currentBrowser = <CardBrowser cubeObjects={this.cubeObjects} onBrowsingModeChanged={this.onBrowsingModeChanged}/>
     }
@@ -103,7 +103,7 @@ export default class PhotoCubeClient extends React.Component<ClientState> {
    */
   onFilterRemoved = (filterId : number) => {
     let callback = () => { if(this.CubeBrowser.current){ this.CubeBrowser.current.RecomputeCells(); }}
-    this.setState({filters : this.state.filters.filter(filter => filter.Id !== filterId)}, callback);
+    this.setState({filters : this.state.filters.filter(filter => filter.id !== filterId)}, callback);
   }
 
   /**
@@ -119,7 +119,7 @@ export default class PhotoCubeClient extends React.Component<ClientState> {
   */
   onFilterReplaced = (oldFilter:Filter, newFilter: Filter) => {
     let callback = () => { if (this.CubeBrowser.current) { this.CubeBrowser.current.RecomputeCells(); } }
-    let newFilters: Filter[] = this.state.filters.filter(filter => filter.Id !== oldFilter.Id);
+    let newFilters: Filter[] = this.state.filters.filter(filter => filter.id !== oldFilter.id);
     newFilters.unshift(newFilter);
     this.setState({ filters: newFilters.flat() }, callback);
   }
@@ -188,6 +188,7 @@ export default class PhotoCubeClient extends React.Component<ClientState> {
    */
   onOpenCubeInCardMode = (cubeObjects: CubeObject[]) => {
     console.log("Opening cube in card mode:");
+    console.log("from opencubeincardmode: ", cubeObjects)
     this.CubeBrowserBrowsingState = this.CubeBrowser.current!.GetCurrentBrowsingState();
     this.cubeObjects = cubeObjects;
     this.setState({BrowsingMode: BrowsingModes.Card});

--- a/PhotoCube/Client/src/components/PhotoCubeClient.tsx
+++ b/PhotoCube/Client/src/components/PhotoCubeClient.tsx
@@ -35,10 +35,8 @@ export default class PhotoCubeClient extends React.Component<ClientState> {
 
   CubeBrowserBrowsingState : BrowsingState|null = null;
   cubeObjects : CubeObject[] = [];
-  infostring : string | any;
-  obj : object | any;
-  s: string|any;
   projectedFilters : Filter[] = [];
+  isProjected: boolean | any;
 
   render() {
     //Conditional rendering:
@@ -51,7 +49,7 @@ export default class PhotoCubeClient extends React.Component<ClientState> {
         onOpenCubeInGridMode={this.onOpenCubeInGridMode}
         filters={this.state.filters}/>
     }else if(this.state.BrowsingMode == BrowsingModes.Grid){
-      currentBrowser = <GridBrowser projectedFilters={this.projectedFilters} s={this.s} obj={this.obj} inforstring={this.infostring} filters={this.state.filters} cubeObjects={this.cubeObjects} onBrowsingModeChanged={this.onBrowsingModeChanged}/>
+      currentBrowser = <GridBrowser isProjected={this.isProjected} projectedFilters={this.projectedFilters} filters={this.state.filters} cubeObjects={this.cubeObjects} onBrowsingModeChanged={this.onBrowsingModeChanged}/>
     }else if(this.state.BrowsingMode == BrowsingModes.Card){
       currentBrowser = <CardBrowser cubeObjects={this.cubeObjects} onBrowsingModeChanged={this.onBrowsingModeChanged}/>
     }
@@ -192,7 +190,6 @@ export default class PhotoCubeClient extends React.Component<ClientState> {
    */
   onOpenCubeInCardMode = (cubeObjects: CubeObject[]) => {
     console.log("Opening cube in card mode:");
-    console.log("from opencubeincardmode: ", cubeObjects)
     this.CubeBrowserBrowsingState = this.CubeBrowser.current!.GetCurrentBrowsingState();
     this.cubeObjects = cubeObjects;
     this.setState({BrowsingMode: BrowsingModes.Card});
@@ -202,14 +199,12 @@ export default class PhotoCubeClient extends React.Component<ClientState> {
   /**
    * Can be called from sub-components to open CubeObject array in GridMode.
    */
-  onOpenCubeInGridMode = (cubeObjects: CubeObject[], infostring: string, obj: object, s: string, projectedFilters: Filter[]) => {
+  onOpenCubeInGridMode = (cubeObjects: CubeObject[], projectedFilters: Filter[], isProjected: boolean) => {
     console.log("Opening cube in grid mode:");
     this.CubeBrowserBrowsingState = this.CubeBrowser.current!.GetCurrentBrowsingState();
     this.cubeObjects = cubeObjects;
-    this.infostring = infostring;
-    this.obj = obj;
-    this.s = s;
     this.projectedFilters = projectedFilters;
+    this.isProjected = isProjected;
     this.setState({BrowsingMode: BrowsingModes.Grid});
     this.rightDock.current!.ChangeBrowsingMode(BrowsingModes.Grid);
   }

--- a/PhotoCube/Client/src/components/RightDock/Dimension.tsx
+++ b/PhotoCube/Client/src/components/RightDock/Dimension.tsx
@@ -23,7 +23,7 @@ export const FilterDropdown =
         updateSelection(e.currentTarget.value);
         const filter: Filter = JSON.parse(e.currentTarget.value);
         const dimension = ({
-            id: filter.Id,
+            id: filter.id,
             name: filter.name,
             type: filter.type
         }) as PickedDimension;
@@ -33,8 +33,8 @@ export const FilterDropdown =
     return (
         <select className="Filter Selector" value={selected} onChange={(e) => createDimension(e)}>
             <option key={0} value={""}>Select filter</option>
-            {options.map(af => (af.type === "tagset" || af.type === "hierarchy") ?
-                <option key={af.Id} value={JSON.stringify(af)}>{af.name}</option> : null)}
+            {options.map(af => (af.type === "tagset" || af.type === "node") ?
+                <option key={af.id} value={JSON.stringify(af)}>{af.name}</option> : null)}
         </select>
     )
 }

--- a/PhotoCube/Client/src/components/RightDock/FilterList.tsx
+++ b/PhotoCube/Client/src/components/RightDock/FilterList.tsx
@@ -17,7 +17,7 @@ export const FilterList = (props: {
             <div id="filterlist-container">
                 <ul className="filter list scrollable">
                     {props.activeFilters.map(filter => (filter.type !== "day of week" && filter.type !== "time" && filter.type !== "date") ?
-                    <li key={filter.Id}>{filter.name}<button className="clear button" onClick={() => props.onFilterRemoved(filter.Id)}>
+                    <li key={filter.id}>{filter.name}<button className="clear button" onClick={() => props.onFilterRemoved(filter.id)}>
                         <AiOutlineCloseCircle id="clear-icon"/></button></li> : null
                     )}
                 </ul>


### PR DESCRIPTION
Right-clicking on a cell will now immediately open that cell in gridmode(gridbrowser).  This works when only one cell is in the browsing state, and when multiple cells are (when some filters are projected on the axes). Not all cases have been tested so there may very well be cases where it does not display the correct images when inspecting a cell. Please use and test and document these cases. For very large cell (with many images) the gridbrowser is capped at 100 images displayed to not overload the image server. Double clicking an image in gridbrowser will trigger a submit to the LSC competition. For this to work there has to be a REACT_APP_IMAGE_SERVER variable set in .env or on the system. This variable should be set to the current session id for the competition. 