### PR TITLE
minimal node/{id} endpoint & node/{id}/tree endpoint with previous behavior

### DIFF
--- a/PhotoCube/Server/ObjectCubeServer/ObjectCubeServer/Models/PublicClasses/PublicNodeDetails.cs
+++ b/PhotoCube/Server/ObjectCubeServer/ObjectCubeServer/Models/PublicClasses/PublicNodeDetails.cs
@@ -1,0 +1,21 @@
+﻿namespace ObjectCubeServer.Models.PublicClasses
+{
+    public class PublicNodeDetails
+    {
+        public int Id { get; set; }
+        public string TagName { get; set; }
+        public int? ParentId { get; set; }
+        
+        public int TagId { get; set; }
+        
+        public int HierarchyId { get; set; }
+
+        public PublicNodeDetails(int id, string tagName, int tagId, int hierarchyId)
+        {
+            Id = id;
+            TagName = tagName;
+            TagId = tagId;
+            HierarchyId = hierarchyId;
+        }
+    }
+}


### PR DESCRIPTION
node/{id} now only returns node related ids and tag name.
comes with new node/{id}/tree endpoint with the previous behavior of node/{id}